### PR TITLE
Add markdown to messages

### DIFF
--- a/app/assets/css/msg.sass
+++ b/app/assets/css/msg.sass
@@ -35,3 +35,32 @@
 .msg__text
   display: block
   overflow: hidden
+
+  p
+    margin: 0
+
+    blockquote
+      padding: 10px 20px
+      margin: 0 0 20px
+      border-left: 5px solid #eee
+
+    code
+      padding: 2px 4px
+      font-size: 90%
+      color: #c7254e
+      background-color: #f9f2f4
+      border-radius: 4px
+
+  pre
+    margin: 0
+    padding: 10px
+    word-break: break-all
+    word-wrap: break-word
+    background-color: #f5f5f5
+    border: 1px solid #ccc
+    border-radius: 4px
+
+    code
+      background-color: inherit
+      border: none
+      color: inherit

--- a/app/assets/css/send.sass
+++ b/app/assets/css/send.sass
@@ -2,6 +2,7 @@
   margin-top: 10px
 
 .send__text
+  display: block
   width: 100%
   min-height: 40px
   padding: 5px 20px
@@ -10,3 +11,4 @@
   border-left: none
   border-right: none
   box-sizing: border-box
+  resize: none

--- a/app/views/components/message.jsx
+++ b/app/views/components/message.jsx
@@ -106,7 +106,8 @@ var ChatComponent = function (socket) {
     },
 
     handleKeyDown: function (e) {
-      if (e.ctrlKey && e.keyCode === 13) {
+      var pressKeys = (e.metaKey || e.ctrlKey) && e.keyCode === 13;
+      if (pressKeys) {
         this.handleSubmit(e);
       }
     },

--- a/app/views/components/message.jsx
+++ b/app/views/components/message.jsx
@@ -1,6 +1,8 @@
 var MessagesStore = require('./../../stores/MessagesStore'); // подключаем стор
 var MessagesActions = require('./../../actions/MessagesActions'); // подключаем экшены
 
+var markDownConverter = new showdown.Converter();
+
 var ChatComponent = function (socket) {
   var ChatBox = React.createClass({
     getInitialState: function () {
@@ -75,7 +77,12 @@ var ChatComponent = function (socket) {
     render: function () {
       return (
         <div className="msg__item">
-          <span className="msg__author">{this.props.message.username}: </span><span className="msg__text">{this.props.message.text}</span>
+          <span className="msg__author">{this.props.message.username}: </span>
+          <div
+            className="msg__text"
+            dangerouslySetInnerHTML={{
+              __html: markDownConverter.makeHtml(this.props.message.text)
+            }} />
         </div>
       );
     }
@@ -98,11 +105,17 @@ var ChatComponent = function (socket) {
 
     },
 
+    handleKeyDown: function (e) {
+      if (e.ctrlKey && e.keyCode === 13) {
+        this.handleSubmit(e);
+      }
+    },
+
     render: function () {
       return (
         <div className='send'>
-          <form className="send__form" onSubmit={this.handleSubmit}>
-            <input className="send__text" name="text" ref="text" placeholder="Сообщение" autoFocus required />
+          <form className="send__form" onSubmit={this.handleSubmit} ref="formMsg">
+            <textarea className="send__text" onKeyDown={this.handleKeyDown} name="text" ref="text" placeholder="Сообщение" autoFocus required />
             <button type="submit" className="hidden" ref="submitButton">Post message</button>
           </form>
         </div>

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "react": "~0.13.3",
     "fontawesome": "~4.0.0",
-    "normalize.css": "~3.0.0"
+    "normalize.css": "~3.0.0",
+    "showdown": "1.2.3"
   }
 }


### PR DESCRIPTION
Использовал [showdown](https://github.com/showdownjs/showdown). Поддерживает все [основные фичи](https://guides.github.com/features/mastering-markdown/) Markdown разметки

Пришлось убрать `input` и вставить `textarea`. При нажатии на `Enter` делается перенос текста, при `Ctrl + Enter` - отправляем сообщение.

P.S. необходимо стилизовать основные элементы для сообщений (код, картинки, цитаты и т.д.)
